### PR TITLE
Published datetime attribute should be in ISO8601 format

### DIFF
--- a/entry.html
+++ b/entry.html
@@ -62,7 +62,7 @@
           <span class="small" style="padding-right: 10px">
             <i class="fa fa-calendar"></i> 
             <a class="small date u-url" href="{{url}}">
-              <time class="dt-published" datetime="{{#formatDate}} DD MMM YYYY HH:MMz {{/formatDate}}">
+              <time class="dt-published" datetime="{{#formatDate}} YYYY-MM-DDTHH:mm:ssZZ {{/formatDate}}">
                 {{#formatDate}} ddd, MMM D, YYYY {{/formatDate}}
               </time>
             </a>            


### PR DESCRIPTION
Hi, noticed this while gaining inspiration from your code. Thanks for the Indieweb articles!
This should probably change in other places too.